### PR TITLE
Camera View Control - The User will be able to swap between different

### DIFF
--- a/lua/ghost_replay/gui/cl_scrubber.lua
+++ b/lua/ghost_replay/gui/cl_scrubber.lua
@@ -17,6 +17,26 @@ function PANEL:Init()
         self:SetPlaying(self.playButton:GetText() == "Play")
     end
 
+
+    --Combo Box for Selecting Camera Angle
+    self.comboBox = vgui.Create("DComboBox", self)
+    self.comboBox:SetValue("Camera")
+    self.comboBox:Dock(LEFT)
+    self.comboBox:DockMargin(8, 64, 8, 8)
+    self.comboBox:SetTall(32)
+    self.comboBox:AddChoice("First Person")
+    self.comboBox:AddChoice("Third Person")
+    self.comboBox:AddChoice("Free Camera")
+    self.comboBox:AddChoice("Death Camera")
+    self.comboBox:AddChoice("Freeze Camera")
+    self.comboBox:AddChoice("Fixed Camera")
+    
+    self.comboBox.OnSelect =  function (self, index, value)
+        net.Start("GhostReplay.ToggleCameraView")
+        net.WriteString(value)
+        net.SendToServer()
+    end
+
     self.slider = vgui.Create("DNumSlider", self)
     self.slider:Dock(FILL)
     self.slider:SetDecimals(0)

--- a/lua/ghost_replay/gui/sh_init.lua
+++ b/lua/ghost_replay/gui/sh_init.lua
@@ -7,6 +7,7 @@ if (SERVER) then
     util.AddNetworkString("GhostReplay.SetFrame")
     util.AddNetworkString("GhostReplay.ScrubTo")
     util.AddNetworkString("GhostReplay.End")
+    util.AddNetworkString("GhostReplay.ToggleCameraView")
 
     net.Receive("GhostReplay.TogglePlayRecording", function(len, ply)
         GhostReplay.Record.SetPaused(ply, ply.GhostReplayReplaying and not ply.GhostReplayReplaying.isPaused or false)
@@ -23,6 +24,11 @@ if (SERVER) then
         GhostReplay.Record.Stop(ply)
         net.Start("GhostReplay.CloseScrubber")
         net.Send(ply)
+    end)
+
+    net.Receive("GhostReplay.ToggleCameraView", function(len, ply)
+        local cameraview = net.ReadString()
+        GhostReplay.Record.ToggleCameraView(ply, cameraview)
     end)
 else
     include("cl_scrubber.lua")

--- a/lua/ghost_replay/record/sv_replay.lua
+++ b/lua/ghost_replay/record/sv_replay.lua
@@ -91,6 +91,23 @@ function GhostReplay.Record.SetPaused(ply, isPaused)
     ply.GhostReplayReplaying.isPaused = isPaused
 end
 
+function GhostReplay.Record.ToggleCameraView(ply, cameraview)
+    if(cameraview == "Death Camera") then
+        ply:Spectate(OBS_MODE_DEATHCAM)
+    elseif (cameraview == "Freeze Camera") then
+        ply:Spectate(OBS_MODE_FREEZECAM)
+    elseif (cameraview == "Fixed Camera") then
+        ply:Spectate(OBS_MODE_FIXED)
+    elseif (cameraview == "First Person") then
+        ply:Spectate(OBS_MODE_IN_EYE)
+    elseif (cameraview == "Third Person") then
+        ply:Spectate(OBS_MODE_CHASE)
+    elseif (cameraview == "Free Camera") then
+        ply:Spectate(OBS_MODE_ROAMING)
+    end
+
+end
+
 function GhostReplay.Record.SetFrame(ply, frameIndex)
     if (not ply.GhostReplayReplaying) then
         return


### PR DESCRIPTION
Camera Views/Angles
-Added a new GUI combo box for selecting options for different camera views
-Added new net.receive events to change the camera view for each option selected using ply:Spectate()
-GhostReplay.Record.ToggleCameraView will now handle all camera change states during recording

What does this change bring?
Users will now be able to select their camera angle while watching their recordings. This opens up new possibilities for more cinematic angles and shots.