### PR TITLE
Animate Entity Throughout Replayed Scene and Hide GUI 

### DIFF
--- a/lua/ghost_replay/gui/cl_scrubber.lua
+++ b/lua/ghost_replay/gui/cl_scrubber.lua
@@ -128,6 +128,7 @@ end)
 hook.Add("GUIMousePressed", "GhostReplay.ControlCamera", function(mouseCode, aimVector)
     if (not IsValid(GhostReplay.Gui)) then return end
 
+    GhostReplay.Gui:SetSize(0, 0)
     GhostReplay.Gui:SetMouseInputEnabled(false)
     GhostReplay.Gui:SetKeyboardInputEnabled(false)
     GhostReplay.Gui.ControllingCamera = true
@@ -139,6 +140,8 @@ hook.Add("Think", "GhostReplay.ReleaseControlCamera", function()
     if (not GhostReplay.Gui.ControllingCamera) then return end
     if (input.IsMouseDown(MOUSE_FIRST)) then return end
 
+    local width = math.min(ScrW() * .9, 800)
+    GhostReplay.Gui:SetSize(width, 128)
     GhostReplay.Gui:SetMouseInputEnabled(true)
     GhostReplay.Gui:SetKeyboardInputEnabled(true)
 end)

--- a/lua/ghost_replay/gui/sh_init.lua
+++ b/lua/ghost_replay/gui/sh_init.lua
@@ -27,8 +27,8 @@ if (SERVER) then
     end)
 
     net.Receive("GhostReplay.ToggleCameraView", function(len, ply)
-        local cameraview = net.ReadString()
-        GhostReplay.Record.ToggleCameraView(ply, cameraview)
+        local cameraView = net.ReadString()
+        GhostReplay.Record.ToggleCameraView(ply, cameraView)
     end)
 else
     include("cl_scrubber.lua")

--- a/lua/ghost_replay/record/sv_record.lua
+++ b/lua/ghost_replay/record/sv_record.lua
@@ -25,28 +25,6 @@ local function fakePlayer(index)
     return fakePlayers[index]
 end
 
-local function makeNewFrame(ply)
-    local lastFrame = ply.GhostReplayRecording[#ply.GhostReplayRecording]
-    local newFrame = {
-        time = CurTime(),
-        appearance = lastFrame and lastFrame.appearance or {},
-        movement = {}
-    }
-
-    ply.GhostReplayRecording[#ply.GhostReplayRecording + 1] = newFrame
-
-    return newFrame
-end
-
-local function getLastRecordedFrameOrNew(ply)
-    local lastFrame = ply.GhostReplayRecording[#ply.GhostReplayRecording]
-
-    if (not lastFrame) then
-        lastFrame = makeNewFrame(ply)
-    end
-
-    return lastFrame
-end
 
 local function getMovement(ply)
     return {
@@ -65,6 +43,28 @@ local function getAppearance(ply)
         material = ply:GetMaterial(),
         sequence = ply:GetSequence(),
     }
+end
+
+local function makeNewFrame(ply)
+    local newFrame = {
+        time = CurTime(),
+        appearance = getAppearance(ply),
+        movement = getMovement(ply)
+    }
+
+    ply.GhostReplayRecording[#ply.GhostReplayRecording + 1] = newFrame
+
+    return newFrame
+end
+
+local function getLastRecordedFrameOrNew(ply)
+    local lastFrame = ply.GhostReplayRecording[#ply.GhostReplayRecording]
+
+    if (not lastFrame) then
+        lastFrame = makeNewFrame(ply)
+    end
+
+    return lastFrame
 end
 
 local function startRecording(ply)

--- a/lua/ghost_replay/record/sv_replay.lua
+++ b/lua/ghost_replay/record/sv_replay.lua
@@ -25,19 +25,6 @@ local function showFrame(ghost, frameToReplay)
         ghost:SetBodyGroups(appearance.bodygroups)
         ghost:SetColor(appearance.color)
         ghost:SetMaterial(appearance.material)
-        ghost:SetMoveType(3)
-        ghost:SetPlaybackRate(1)
-
-        if(string.match(ghost:GetSequenceActivityName(appearance.sequence), "SPRINT") or string.match(ghost:GetSequenceActivityName(appearance.sequence), "JUMP")) then
-            ghost:SetSequence(appearance.sequence)
-            ghost:SetCycle(CurTime() % 1)
-        elseif (string.match(ghost:GetSequenceActivityName(appearance.sequence), "RUN")) then
-            ghost:SetSequence( ghost:LookupSequence( "menu_walk" ) )
-		    ghost:SetCycle(CurTime() % 1)
-        else
-            ghost:SetSequence(ghost:LookupSequence( "idle_all_01" ))
-            ghost:SetCycle(CurTime() % 1)
-        end
    end
 
     local movement = frameToReplay.movement
@@ -45,6 +32,26 @@ local function showFrame(ghost, frameToReplay)
     ghost:SetPos(movement.pos)
     ghost:SetAngles(movement.ang)
     ghost:SetVelocity(movement.vel)
+    ghost:SetMoveType(3)
+    ghost:SetPlaybackRate(1)
+
+    if(string.match(ghost:GetSequenceActivityName(appearance.sequence), "SPRINT") or string.match(ghost:GetSequenceActivityName(appearance.sequence), "JUMP")) then
+        ghost:SetSequence(appearance.sequence)
+        ghost:SetCycle(CurTime() % 1)
+    elseif (string.match(ghost:GetSequenceActivityName(appearance.sequence), "RUN")) then
+        ghost:SetSequence( ghost:LookupSequence( "menu_walk" ) )
+		ghost:SetCycle(CurTime() % 1)
+    else
+        ghost:SetSequence(ghost:LookupSequence( "idle_all_01" ))
+        ghost:SetCycle(CurTime() % 1)
+    end
+
+    if (ghost.curPos ~= movement.pos) then
+        ghost.curPos = movement.pos
+    else
+        ghost:SetSequence(ghost:LookupSequence( "idle_all_01" ))
+        ghost:SetCycle(CurTime() % 1)
+    end
 end
 
 function GhostReplay.Record.Replay(ply, recording)
@@ -54,8 +61,7 @@ function GhostReplay.Record.Replay(ply, recording)
     end
 
     local ghostEntity = ents.Create("ghost_replay_ghost")
-    ghostEntity.lastSequence = 0
-    ghostEntity.altSequence = 0
+    ghostEntity.curPos = nil
     ghostEntity:SetPos(ply:GetPos())
     ghostEntity:Spawn()
 
@@ -177,7 +183,6 @@ hook.Add("Think", "GhostReplay.Record.ReplayThink", function()
 
             if (timeSinceStart >= frameToReplay.time + frameDelay) then
                 local nextFrame = replaying.recording[frameToReplay.frameIndex + 1]
-
                 if (nextFrame) then
                     queueFrameForReplay(ply, replaying.recording, frameToReplay.frameIndex + 1, frameDelay)
                 end

--- a/lua/ghost_replay/record/sv_replay.lua
+++ b/lua/ghost_replay/record/sv_replay.lua
@@ -25,8 +25,20 @@ local function showFrame(ghost, frameToReplay)
         ghost:SetBodyGroups(appearance.bodygroups)
         ghost:SetColor(appearance.color)
         ghost:SetMaterial(appearance.material)
-        ghost:SetSequence(appearance.sequence)
-    end
+        ghost:SetMoveType(3)
+        ghost:SetPlaybackRate(1)
+
+        if(string.match(ghost:GetSequenceActivityName(appearance.sequence), "SPRINT") or string.match(ghost:GetSequenceActivityName(appearance.sequence), "JUMP")) then
+            ghost:SetSequence(appearance.sequence)
+            ghost:SetCycle(CurTime() % 1)
+        elseif (string.match(ghost:GetSequenceActivityName(appearance.sequence), "RUN")) then
+            ghost:SetSequence( ghost:LookupSequence( "menu_walk" ) )
+		    ghost:SetCycle(CurTime() % 1)
+        else
+            ghost:SetSequence(ghost:LookupSequence( "idle_all_01" ))
+            ghost:SetCycle(CurTime() % 1)
+        end
+   end
 
     local movement = frameToReplay.movement
 
@@ -42,6 +54,8 @@ function GhostReplay.Record.Replay(ply, recording)
     end
 
     local ghostEntity = ents.Create("ghost_replay_ghost")
+    ghostEntity.lastSequence = 0
+    ghostEntity.altSequence = 0
     ghostEntity:SetPos(ply:GetPos())
     ghostEntity:Spawn()
 
@@ -91,18 +105,18 @@ function GhostReplay.Record.SetPaused(ply, isPaused)
     ply.GhostReplayReplaying.isPaused = isPaused
 end
 
-function GhostReplay.Record.ToggleCameraView(ply, cameraview)
-    if(cameraview == "Death Camera") then
+function GhostReplay.Record.ToggleCameraView(ply, cameraView)
+    if(cameraView == "Death Camera") then
         ply:Spectate(OBS_MODE_DEATHCAM)
-    elseif (cameraview == "Freeze Camera") then
+    elseif (cameraView == "Freeze Camera") then
         ply:Spectate(OBS_MODE_FREEZECAM)
-    elseif (cameraview == "Fixed Camera") then
+    elseif (cameraView == "Fixed Camera") then
         ply:Spectate(OBS_MODE_FIXED)
-    elseif (cameraview == "First Person") then
+    elseif (cameraView == "First Person") then
         ply:Spectate(OBS_MODE_IN_EYE)
-    elseif (cameraview == "Third Person") then
+    elseif (cameraView == "Third Person") then
         ply:Spectate(OBS_MODE_CHASE)
-    elseif (cameraview == "Free Camera") then
+    elseif (cameraView == "Free Camera") then
         ply:Spectate(OBS_MODE_ROAMING)
     end
 


### PR DESCRIPTION
HideGUI - Hide the GUI when the user controls the camera and player entity is now animated* throughout the replay
-Quality of life adjustments to HideGUI from user when they control the camera/click outside of the gui
-Player model entity is now animated according to the replay animation sequence (However, this feature is heavily limited and both the idle and walk animations have been hardcoded to "menu_walk" and "idle_all_01" which may not be representative of the actual gameplay)

What does this change bring?
Now player entities will be animated throughout your replay! No more of the stiff guy floating through space. The user will also now be able to hide the scrubber gui when they click in to control the camera. GUI returns to normal after the user releases control of the camera. 
![2024-01-09 17-17-48](https://github.com/luttje/gmod-ghost-replay/assets/78187414/9892aaed-72a4-408b-877f-83b2d58703fd)

